### PR TITLE
feat: added `edit` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.12.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mitchellh/go-homedir v1.1.0
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"github.com/fatih/color"
+	"github.com/google/shlex"
 	"github.com/manifoldco/promptui"
 	"github.com/mitchellh/go-homedir"
 	"io"
@@ -171,19 +172,17 @@ func main() {
 				editor = "vim"
 
 				if runtime.GOOS == "windows" {
-					editor = "notepad++"
+					editor = "notepad"
 				}
 			}
 
-			split := strings.Split(editor, " ")
+			split, err := shlex.Split(editor)
+			if err != nil {
+				split = []string{strings.Split(editor, " ")[0]}
+			}
 			split = append(split, gitConfig)
 
-			executableEditor, err := exec.LookPath(split[0])
-			if err != nil {
-				color.HiRed("Please set the $EDITOR environment variable or install vim.")
-			}
-
-			cmd := exec.Command(executableEditor, split[1:]...)
+			cmd := exec.Command(split[0], split[1:]...)
 			cmd.Stdin = os.Stdin
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 func main() {
@@ -174,11 +175,21 @@ func main() {
 				}
 			}
 
-			cmd := exec.Command(editor, gitConfig)
+			split := strings.Split(editor, " ")
+			split = append(split, gitConfig)
+
+			editor = split[0]
+			executableEditor, err := exec.LookPath(editor)
+			if err != nil {
+				color.HiRed("Please set the $EDITOR environment variable or install vim.")
+			}
+
+			cmd := exec.Command(executableEditor, split[1:]...)
 			cmd.Stdin = os.Stdin
 			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
 			if err = cmd.Run(); err != nil {
-				color.HiRed("Please set the $EDITOR environment variable or install vim.")
+				color.HiRed("Err %s", err)
 			}
 		}
 	} else if len(configs) >= 1 {

--- a/main.go
+++ b/main.go
@@ -178,8 +178,7 @@ func main() {
 			split := strings.Split(editor, " ")
 			split = append(split, gitConfig)
 
-			editor = split[0]
-			executableEditor, err := exec.LookPath(editor)
+			executableEditor, err := exec.LookPath(split[0])
 			if err != nil {
 				color.HiRed("Please set the $EDITOR environment variable or install vim.")
 			}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,9 @@ import (
 	"io/fs"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 func main() {
@@ -162,7 +164,22 @@ func main() {
 			if err != nil {
 				log.Panic(err)
 			}
+		case "edit":
+			editor := os.Getenv("EDITOR")
+			if editor == "" {
+				editor = "vim"
 
+				if runtime.GOOS == "windows" {
+					editor = "notepad++"
+				}
+			}
+
+			cmd := exec.Command(editor, gitConfig)
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			if err = cmd.Run(); err != nil {
+				color.HiRed("Please set the $EDITOR environment variable or install vim.")
+			}
 		}
 	} else if len(configs) >= 1 {
 		// List git configs


### PR DESCRIPTION
Hi Kaan, I think we needed a command to quickly edit the profile's config.

**Flow:** 
- Check EDITOR env. var
  - if exists: run command with default EDITOR
  - if not exists:
    - set default editor to vim (also if runtime.GOOS equal windows, set default editor to notepad++) and run command
 - Check error and finish job
 